### PR TITLE
Test measurement and data_header loops. Fix add numerical values.

### DIFF
--- a/exampleparser/metainfo.py
+++ b/exampleparser/metainfo.py
@@ -22,6 +22,7 @@ import numpy as np
 from nomad.datamodel import EntryArchive
 from nomad.metainfo.metainfo import Datetime
 
+
 class DeviceSettings(MSection):
     device_name = Quantity(type=str)
     analysis_method = Quantity(type=str)
@@ -32,19 +33,23 @@ class DeviceSettings(MSection):
     workfunction = Quantity(type=str)
     channel_id = Quantity(type=str)
 
+
 class Sample(MSection):
     spectrum_region = Quantity(type=str, shape=[])
 
+
 class Experiment(MSection):
     method_type = Quantity(type=str)
+
 
 class Instrument(MSection):
     n_scans = Quantity(type=str)
     dwell_time = Quantity(type=str)
     excitation_energy = Quantity(type=str)
     source_label = Quantity(type=str)
-    
+
     section_device_settings = SubSection(sub_section=DeviceSettings, repeats=True)
+
 
 class AuthorGenerated(MSection):
     author_name = Quantity(type=str)
@@ -53,13 +58,16 @@ class AuthorGenerated(MSection):
     experiment_id = Quantity(type=str)
     timestamp = Quantity(type=str)
 
+
 class DataHeader(MSection):
     channel_id = Quantity(type=str)
     label = Quantity(type=str)
     unit = Quantity(type=str)
 
+
 class NumericalValues(MSection):
-    data_values = Quantity(type=np.dtype(np.float64), shape=['*'])
+    data_values = Quantity(type=np.dtype(np.float64), shape=['*', '*'])
+
 
 class Metadata(MSection):
     section_sample = SubSection(sub_section=Sample, repeats=True)
@@ -68,12 +76,15 @@ class Metadata(MSection):
     section_author_generated = SubSection(sub_section=AuthorGenerated, repeats=True)
     section_data_header = SubSection(sub_section=DataHeader, repeats=True)
 
+
 class Data(MSection):
     section_numerical_values = SubSection(sub_section=NumericalValues, repeats=True)
+
 
 class Measurement(MSection):
     section_metadata = SubSection(sub_section=Metadata, repeats=True)
     section_data = SubSection(sub_section=Data, repeats=True)
+
 
 class MyEntryArchive(EntryArchive):
     m_def = Section(extends_base_section=True)

--- a/exampleparser/parser.py
+++ b/exampleparser/parser.py
@@ -46,96 +46,52 @@ class ExampleParser(FairdiParser):
         # Log a hello world, just to get us started. TODO remove from an actual parser.
         logger.info('Testing the World')
 
-        #Read the JSON file into a dictionary
+        # Read the JSON file into a dictionary
         with open(mainfile, 'rt') as f:
             file_data = json.load(f)
 
-        #Reading a measurement
-        measurement = archive.m_create(Measurement)
+        for measurement_data in file_data:
+            # Reading a measurement
+            measurement = archive.m_create(Measurement)
 
-        #Create the hierarchical structure
-        metadata = measurement.m_create(Metadata)
-        data = measurement.m_create(Data)
+            # Create the hierarchical structure
+            metadata = measurement.m_create(Metadata)
+            data = measurement.m_create(Data)
 
-        # Create the hierarchical structure inside metadata
-        sample = metadata.m_create(Sample)
-        experiment = metadata.m_create(Experiment)
-        instrument = metadata.m_create(Instrument)
-        data_header = metadata.m_create(DataHeader)
-        author_generated = metadata.m_create(AuthorGenerated)
+            # Create the hierarchical structure inside metadata
+            sample = metadata.m_create(Sample)
+            experiment = metadata.m_create(Experiment)
+            instrument = metadata.m_create(Instrument)
+            author_generated = metadata.m_create(AuthorGenerated)
 
-        #Load entries into each above hierarchical structure
-        #Sample
-        sample.spectrum_region = file_data[0]['metadata']['spectrum_region']
+            # Load entries into each above hierarchical structure
+            # Sample
+            sample.spectrum_region = measurement_data['metadata']['spectrum_region']
 
-        #Experiment
-        experiment.method_type = file_data[0]['metadata']['method_type']
+            # Experiment
+            experiment.method_type = measurement_data['metadata']['method_type']
 
-        #Instrument
-        instrument.n_scans = file_data[0]['metadata']['n_scans']
-        instrument.dwell_time = file_data[0]['metadata']['dwell_time']
-        instrument.excitation_energy = file_data[0]['metadata']['excitation_energy']
+            # Instrument
+            instrument.n_scans = measurement_data['metadata']['n_scans']
+            instrument.dwell_time = measurement_data['metadata']['dwell_time']
+            instrument.excitation_energy = measurement_data['metadata']['excitation_energy']
 
-        if file_data[0]['metadata']['source_label']:
-            instrument.source_label = file_data[0]['metadata']['source_label']
-        
-        author_generated.author_name = file_data[0]['metadata']['author']
-        author_generated.group_name = file_data[0]['metadata']['group_name']
-        author_generated.sample_id = file_data[0]['metadata']['sample']
-        author_generated.experiment_id = file_data[0]['metadata']['experiment_id']
-        author_generated.timestamp = file_data[0]['metadata']['timestamp']
+            if measurement_data['metadata']['source_label']:
+                instrument.source_label = measurement_data['metadata']['source_label']
 
-        #Data Header
-        for dlabel in file_data[0]['metadata']['data_labels']: 
-            data_header.channel_id = str(dlabel['channel_id'])
-            data_header.label = dlabel['label']
-            data_header.unit = dlabel['unit']
+            author_generated.author_name = measurement_data['metadata']['author']
+            author_generated.group_name = measurement_data['metadata']['group_name']
+            author_generated.sample_id = measurement_data['metadata']['sample']
+            author_generated.experiment_id = measurement_data['metadata']['experiment_id']
+            author_generated.timestamp = measurement_data['metadata']['timestamp']
 
-        #Reading columns
-        numerical_values = data.m_create(NumericalValues)
-        numerical_values.data = file_data[0]['data'][0]
-        
+            # Data Header
+            for label_data in measurement_data['metadata']['data_labels']:
+                data_header = metadata.m_create(DataHeader)
+                data_header.channel_id = str(label_data['channel_id'])
+                data_header.label = label_data['label']
+                data_header.unit = label_data['unit']
 
-
-        # for item in file_data:
-
-        #     measurement = archive.m_create(Measurement)
-        #     # measurement.timestamp = datetime.datetime.now()
-
-        #     metadata = measurement.m_create(Metadata)
-
-        #     sample = metadata.m_create(Sample)
-        #     sample.spectrum_region = item['metadata']['spectrum_region']
-
-        #     # experiment = metadata.m_create(Experiment)
-        #     # experiment.method_type = data[i]['metadata']['method_type']
-
-        #     # instrument = metadata.m_create(Instrument)
-        #     # instrument.n_scans = data[i]['metadata']['n_scans']
-        #     # instrument.dwell_time = data[i]['metadata']['dwell_time']
-        #     # instrument.excitation_energy = data[i]['metadata']['excitation_energy']
-            
-
-        #     # try:
-        #     #     instrument.source_label = data[i]['metadata']['source_label']
-        #     # except KeyError:
-        #     #     print("Couldn't find key")
-
-        #     # author_generated = metadata.m_create(AuthorGenerated)
-        #     # author_generated.author_name = data[i]['metadata']['author']
-        #     # author_generated.group_name = data[i]['metadata']['group_name']
-        #     # author_generated.sample_id = data[i]['metadata']['sample']
-        #     # author_generated.experiment_id = data[i]['metadata']['experiment_id']
-        #     # author_generated.timestamp = data[i]['metadata']['timestamp']
-
-        #     data_header = metadata.m_create(DataHeader)
-        #     for dlabel in item['metadata']['data_labels']: 
-        #         data_header.channel_id = str(dlabel['channel_id'])
-        #         data_header.label = dlabel['label']
-        #         data_header.unit = dlabel['unit']
-
-        #     # data = measurement.m_create(Data)
-
-        #     # numerical_values = data.m_create(NumericalValues)
-        #     # # numerical_values.data_values = data[0]['data'][0]
-        
+            # Reading columns
+            numerical_values = data.m_create(NumericalValues)
+            numerical_values.data_values = measurement_data['data']


### PR DESCRIPTION
- added a loop to cover all measurements in the file
- moved the `m_create` for `DataHeader` into the respective loop
- fixed the wrong quantity name for `data_values` 

Other comments:
- you should go with specific definitions for spectra data instead of the general `data_header` + `data_values` thing as we discussed on Friday. 
- the `AuthorGenerated` subsection is not good. It mixes categories like sample, experiment, instrument, author with categories like human generated, instrument generated, ... You can have a section Author, but `sample_id`, `experiment_id` should go to the respective sections. You can use [categories](https://nomad-lab.eu/prod/rae/docs/metainfo.html#categories) to add categories like `UserGenerated` if necessary.
- I don't think that a timestamp is ever "author generated". More top-level sections like `(Measurement)Metadata` can also have quantities (e.g. timestamp).